### PR TITLE
Un seul évenement TIME_TO_SUBMIT par tour

### DIFF
--- a/models/game.js
+++ b/models/game.js
@@ -30,6 +30,7 @@ const gameSchema = new Schema({
   timestamps: true
 })
 
+const cacheKeyResolver = ({ _id, turn }) => `${_id}-${turn}`;
 const memoizedPublishTimeToSubmit = _.memoize(({ _id, turn }, delay = 60000) => {
     return new Promise((resolve) => {
         setTimeout(() => {
@@ -40,11 +41,11 @@ const memoizedPublishTimeToSubmit = _.memoize(({ _id, turn }, delay = 60000) => 
                 }
             });
             debug("LOOPING FROM SUBMITQUEUE!")
-            memoizedPublishTimeToSubmit.cache.clear();
+            memoizedPublishTimeToSubmit.cache.delete(cacheKeyResolver({ _id, turn }));
             resolve();
         }, delay);
     })
-}, ({ _id, turn }) => `${_id}-${turn}`)
+}, cacheKeyResolver)
 gameSchema.statics.publishTimeToSubmit = memoizedPublishTimeToSubmit;
 
 gameSchema.statics.checkCompletedTurn = async function (gameId) {

--- a/models/game.js
+++ b/models/game.js
@@ -30,16 +30,15 @@ const gameSchema = new Schema({
   timestamps: true
 })
 
-gameSchema.methods.turnIsOver = () => {
+gameSchema.methods.currentTurnIsOver = function() {
     const turnCount = (+this.turn)+1;
-    return _.every(
-        sketchbooks,
-        sketchbook => _.size(sketchbook.pages) >= turnCount
+    return this.sketchbooks.every(
+        sketchbook => sketchbook.pages.length >= turnCount
     );
 }
 
-gameSchema.methods.isOver = () => {
-   return this.status === 'over' || +this.turn >= _.size(this.players)
+gameSchema.methods.isOver = function() {
+   return this.status === 'over' || +this.turn >= this.players.length
 }
 
 const cacheKeyResolver = ({ _id, turn }) => `${_id}-${turn}`;
@@ -65,7 +64,7 @@ gameSchema.statics.checkCompletedTurn = async function (gameId) {
         .populate('sketchbooks')
         .populate('players')
 
-    if(game.turnIsOver()) {
+    if(game.currentTurnIsOver()) {
       debug('ALL RESPONSES RECEIVED CALLED FROM GAME STATIC METHOD')
       game.turn=(+game.turn+1)
       if(game.isOver()){

--- a/models/game.js
+++ b/models/game.js
@@ -29,10 +29,21 @@ const gameSchema = new Schema({
   timestamps: true
 })
 
+gameSchema.statics.publishTimeToSubmit = (game) => {
+    setTimeout(() => {
+        pubsub.publish("TIME_TO_SUBMIT", {
+            timeToSubmit: {
+                id: game._id.toString()
+            }
+        });
+        debug("LOOPING FROM SUBMITQUEUE!")
+    }, 60000);
+}
+
 gameSchema.statics.checkCompletedTurn = async function (gameId) {
     const game = await this.findById(gameId)
-    .populate('sketchbooks')
-    .populate('players')
+        .populate('sketchbooks')
+        .populate('players')
     // debug(game.sketchbooks.forEach(element => {
     //     debug(element.pages)
     // }))
@@ -46,10 +57,7 @@ gameSchema.statics.checkCompletedTurn = async function (gameId) {
       await game.save()
       pubsub.publish("GAME_UPDATE", { gameUpdate: game});
       debug('ALL RESPONSES RECEIVED DONE')
-      setTimeout(() =>{
-        pubsub.publish("TIME_TO_SUBMIT", {timeToSubmit: {id: game._id.toString()}});
-        debug("LOOPING FROM SUBMITQUEUE!")
-      }, 60000);
+      this.publishTimeToSubmit(game);
     }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5552,8 +5552,7 @@
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-      "dev": true
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash.includes": {
       "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "graphql": "^14.6.0",
     "graphql-passport": "^0.6.3",
     "jsonwebtoken": "^8.5.1",
+    "lodash": "^4.17.15",
     "mongoose": "^5.9.5",
     "mongoose-queue": "^0.3.3",
     "node-cron": "^2.0.3",

--- a/tests/models/game.spec.js
+++ b/tests/models/game.spec.js
@@ -1,0 +1,163 @@
+const { Game } = require('../../models');
+const { pubsub } = require('../../schema');
+
+jest.mock('../../schema', () => ({
+    pubsub: {
+        publish: jest.fn()
+    }
+}))
+
+const mockSave = jest.fn();
+const mockGameInstance = {
+    save: mockSave,
+}
+const mockGameQuery = {
+    populate: () => mockGameQuery,
+    then: (resolve) => resolve(mockGameInstance),
+}
+const mockFindById = jest.fn();
+Game.findById = mockFindById;
+
+describe('Game', () => {
+    beforeEach(() => {
+        jest.resetAllMocks();
+        mockFindById.mockReturnValue(mockGameQuery)
+        mockGameInstance.sketchbooks = [];
+        mockGameInstance.players = [];
+        mockGameInstance.status = 'new';
+    })
+
+    describe('publishTimeToSubmit', () => {
+        it('publie TIME_TO_SUBMIT', async () => {
+            await Game.publishTimeToSubmit({_id: 'id', turn: 1}, 1)
+            expect(pubsub.publish).toHaveBeenCalledTimes(1)
+            expect(pubsub.publish).toHaveBeenCalledWith('TIME_TO_SUBMIT', {
+                timeToSubmit: {
+                    id: 'id',
+                    turn: 0
+                }
+            })
+        })
+
+        it('appelé 1 seule fois par partie-tour', async () => {
+            await Promise.all([
+                Game.publishTimeToSubmit({_id: 'a', turn: 1}, 0),
+                Game.publishTimeToSubmit({_id: 'a', turn: 1}, 0),
+                Game.publishTimeToSubmit({_id: 'a', turn: 2}, 0),
+                Game.publishTimeToSubmit({_id: 'a', turn: 2}, 0),
+                Game.publishTimeToSubmit({_id: 'b', turn: 3}, 0),
+                Game.publishTimeToSubmit({_id: 'b', turn: 3}, 0),
+            ])
+            expect(pubsub.publish).toHaveBeenCalledTimes(3)
+            expect(pubsub.publish).toHaveBeenNthCalledWith(1, 'TIME_TO_SUBMIT', {
+                timeToSubmit: {
+                    id: 'a',
+                    turn: 0
+                }
+            })
+            expect(pubsub.publish).toHaveBeenNthCalledWith(2, 'TIME_TO_SUBMIT', {
+                timeToSubmit: {
+                    id: 'a',
+                    turn: 1
+                }
+            })
+            expect(pubsub.publish).toHaveBeenNthCalledWith(3, 'TIME_TO_SUBMIT', {
+                timeToSubmit: {
+                    id: 'b',
+                    turn: 2
+                }
+            })
+        })
+    })
+
+    describe('checkCompletedTurn', () => {
+        const mockTimeToSubmit = jest.fn();
+        let originalPublishTimeToSubmit;
+        beforeAll(() => {
+            originalPublishTimeToSubmit = Game.publishTimeToSubmit;
+            Game.publishTimeToSubmit = mockTimeToSubmit;
+        })
+
+        afterAll(() => {
+            Game.publishTimeToSubmit = originalPublishTimeToSubmit
+        })
+
+        describe('tous les sketchbooks ne sont pas remplis pour le tour', () => {
+            it('ne fait rien', async () => {
+                mockGameInstance.turn = 1;
+                mockGameInstance.sketchbooks = [
+                    { pages: [1, 2] },
+                    { pages: [] },
+                ]
+                const gameId = 'gameId';
+                await Game.checkCompletedTurn(gameId)
+
+                expect(mockFindById).toHaveBeenCalledTimes(1);
+                expect(mockFindById).toHaveBeenCalledWith(gameId);
+
+                expect(mockTimeToSubmit).toHaveBeenCalledTimes(0);
+                expect(mockSave).toHaveBeenCalledTimes(0);
+                expect(pubsub.publish).toHaveBeenCalledTimes(0);
+            })
+        })
+
+        describe('les sketchbooks sont remplis pour le tour', () => {
+            it('incrémentation du tour', async () => {
+                mockGameInstance.turn = 0;
+                mockGameInstance.sketchbooks = [
+                    { pages: [1] },
+                    { pages: [1] },
+                ]
+                const gameId = 'gameId';
+                await Game.checkCompletedTurn(gameId)
+
+                expect(mockFindById).toHaveBeenCalledTimes(1);
+                expect(mockFindById).toHaveBeenCalledWith(gameId);
+
+                expect(mockTimeToSubmit).toHaveBeenCalledTimes(1);
+                expect(mockTimeToSubmit).toHaveBeenCalledWith(mockGameInstance);
+
+                expect(mockSave).toHaveBeenCalledTimes(1);
+                expect(pubsub.publish).toHaveBeenCalledTimes(1);
+                expect(pubsub.publish).toHaveBeenCalledWith(
+                    'GAME_UPDATE',
+                    { gameUpdate: mockGameInstance }
+                );
+            })
+
+            it('le jeu est fini quand chaque sketchbook est passé par chaque joueur', async () => {
+                mockGameInstance.turn = 1;
+                mockGameInstance.sketchbooks = [
+                    { pages: [1,2] },
+                    { pages: [1,2] },
+                ]
+                mockGameInstance.players = [
+                    {},
+                    {},
+                ]
+                const gameId = 'gameId';
+                await Game.checkCompletedTurn(gameId)
+
+                expect(mockGameInstance.status).toEqual('over');
+            })
+
+            it('le jeu n\'est pas fini tant que chaque sketchbook n\'est pas passé par chaque joueur', async () => {
+                mockGameInstance.turn = 0;
+                mockGameInstance.sketchbooks = [
+                    { pages: [1] },
+                    { pages: [1] },
+                ]
+                mockGameInstance.players = [
+                    {},
+                    {},
+                    {}
+                ]
+                const gameId = 'gameId';
+                await Game.checkCompletedTurn(gameId)
+
+                expect(mockGameInstance.status).toEqual('new');
+            })
+        })
+
+    })
+})

--- a/tests/models/game.spec.js
+++ b/tests/models/game.spec.js
@@ -8,8 +8,12 @@ jest.mock('../../schema', () => ({
 }))
 
 const mockSave = jest.fn();
+const mockIsOver = jest.fn();
+const mockTurnIsOver = jest.fn();
 const mockGameInstance = {
     save: mockSave,
+    isOver: mockIsOver,
+    turnIsOver: mockTurnIsOver
 }
 const mockGameQuery = {
     populate: () => mockGameQuery,
@@ -84,11 +88,7 @@ describe('Game', () => {
 
         describe('tous les sketchbooks ne sont pas remplis pour le tour', () => {
             it('ne fait rien', async () => {
-                mockGameInstance.turn = 1;
-                mockGameInstance.sketchbooks = [
-                    { pages: [1, 2] },
-                    { pages: [] },
-                ]
+                mockTurnIsOver.mockReturnValue(false)
                 const gameId = 'gameId';
                 await Game.checkCompletedTurn(gameId)
 
@@ -102,12 +102,11 @@ describe('Game', () => {
         })
 
         describe('les sketchbooks sont remplis pour le tour', () => {
+            beforeEach(() => {
+                mockTurnIsOver.mockReturnValue(true)
+            })
+
             it('incrémentation du tour', async () => {
-                mockGameInstance.turn = 0;
-                mockGameInstance.sketchbooks = [
-                    { pages: [1] },
-                    { pages: [1] },
-                ]
                 const gameId = 'gameId';
                 await Game.checkCompletedTurn(gameId)
 
@@ -126,15 +125,7 @@ describe('Game', () => {
             })
 
             it('le jeu est fini quand chaque sketchbook est passé par chaque joueur', async () => {
-                mockGameInstance.turn = 1;
-                mockGameInstance.sketchbooks = [
-                    { pages: [1,2] },
-                    { pages: [1,2] },
-                ]
-                mockGameInstance.players = [
-                    {},
-                    {},
-                ]
+                mockGameInstance.isOver.mockReturnValue(true)
                 const gameId = 'gameId';
                 await Game.checkCompletedTurn(gameId)
 
@@ -142,16 +133,7 @@ describe('Game', () => {
             })
 
             it('le jeu n\'est pas fini tant que chaque sketchbook n\'est pas passé par chaque joueur', async () => {
-                mockGameInstance.turn = 0;
-                mockGameInstance.sketchbooks = [
-                    { pages: [1] },
-                    { pages: [1] },
-                ]
-                mockGameInstance.players = [
-                    {},
-                    {},
-                    {}
-                ]
+                mockGameInstance.isOver.mockReturnValue(false)
                 const gameId = 'gameId';
                 await Game.checkCompletedTurn(gameId)
 

--- a/tests/models/game.spec.js
+++ b/tests/models/game.spec.js
@@ -1,4 +1,4 @@
-const { Game } = require('../../models');
+const { Game, User, Sketchbook, Page } = require('../../models');
 const { pubsub } = require('../../schema');
 
 jest.mock('../../schema', () => ({
@@ -13,7 +13,7 @@ const mockTurnIsOver = jest.fn();
 const mockGameInstance = {
     save: mockSave,
     isOver: mockIsOver,
-    turnIsOver: mockTurnIsOver
+    currentTurnIsOver: mockTurnIsOver
 }
 const mockGameQuery = {
     populate: () => mockGameQuery,
@@ -140,6 +140,55 @@ describe('Game', () => {
                 expect(mockGameInstance.status).toEqual('new');
             })
         })
+    })
 
+    describe('methods', () => {
+        describe('isOver', () => {
+            it('retourne true quand le jeu est fini', () => {
+                const game = new Game({
+                    turn: 1,
+                    players: [
+                        new User()
+                    ]
+                })
+                expect(game.isOver()).toBe(true)
+            })
+
+            it('retourne false quand le jeu n\'est pas fini', () => {
+                const game = new Game({
+                    turn: 0,
+                    players: [
+                        new User()
+                    ]
+                })
+                expect(game.isOver()).toBe(false)
+            })
+        })
+
+        describe('currentTurnIsOver', () => {
+            it('retourne true quand le tour est fini', () => {
+                const game = new Game({
+                    turn: 0,
+                    sketchbooks: [
+                        new Sketchbook({
+                            pages: [new Page()]
+                        })
+                    ]
+                })
+                expect(game.currentTurnIsOver()).toBe(true)
+            })
+
+            it('retourne false quand le tour n\'est pas fini', () => {
+                const game = new Game({
+                    turn: 0,
+                    sketchbooks: [
+                        new Sketchbook({
+                            pages: []
+                        })
+                    ]
+                })
+                expect(game.currentTurnIsOver()).toBe(false)
+            })
+        })
     })
 })


### PR DESCRIPTION
Comme tu l'as dit ce n'est pas très grave que cet évènement soit envoyé plusieurs fois à partir du moment où le client prend en compte cette éventualité.

Mais je propose quand même une façon de faire. Elle est imparfaite parce qu'elle n'assure pas à 100% qu'il n'y aura qu'une et une seule émission de l'évènement.

J'ai utilisé la [memoization](https://www.freecodecamp.org/news/understanding-memoize-in-javascript-51d07d19430e/) de [lodash](https://lodash.com/docs/4.17.15#memoize) pour exécuter une seule fois la fonction pour une paire game._id + game.turn.

fix #8 